### PR TITLE
[sc-84298]: switch to using a Github hosted runner for e2e testing

### DIFF
--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -18,11 +18,6 @@
           required: false
           default: ghcr.io/calyptia/cloud:latest
           description: docker image of calyptia/cloud
-        core-image:
-          type: string
-          required: false
-          default: ghcr.io/calyptia/core:main
-          description: docker image of calyptia-core
         core-operator-image:
           type: string
           required: false
@@ -52,11 +47,6 @@
           required: false
           default: ghcr.io/calyptia/cloud-lua-sandbox:latest
           description: docker image of calyptia/cloud-lua-sandbox
-        fluentd-version:
-          type: string
-          required: false
-          default: v1.2-debian
-          description: fluentd image version to use from fluent/fluentd dockerhub.
         ref:
           description: The commit, tag or branch of the cloud-e2e repository to checkout
           type: string
@@ -70,13 +60,13 @@
           description: The runner to use for tests.
           type: string
           required: false
-          default: actuated-4cpu-16gb
+          default: ubuntu-latest-m
         k8s-distribution:
           description: The K8S distribution to use for tests.
           type: string
           # options:
           #   - 'kind'
-          #   - 'openshift'
+          #   - 'vcluster'
           default: kind
           required: false
         gke-cluster-name:
@@ -115,11 +105,9 @@
           required: false # TODO: switch over once done
   env:
     AWS_EC2_METADATA_DISABLED: true
-    FLUENTD_VERSION: ${{ inputs.fluentd-version }}
     CALYPTIA_CLI_VERSION: ${{ inputs.cli-version }}
     CALYPTIA_CLI_IMAGE: ${{ inputs.cli-image }}
     CALYPTIA_CLOUD_IMAGE: ${{ inputs.cloud-image }}
-    CALYPTIA_CORE_IMAGE: ${{ inputs.core-image }}
     CALYPTIA_CORE_OPERATOR_IMAGE: ${{ inputs.core-operator-image }}
     CALYPTIA_CORE_OPERATOR_FROM_CLOUD_IMAGE: ${{ inputs.core-operator-from-cloud-image }}
     CALYPTIA_CORE_OPERATOR_TO_CLOUD_IMAGE: ${{ inputs.core-operator-to-cloud-image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
       cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
-      core-image: ghcr.io/calyptia/core:${{ needs.ci-get-metadata.outputs.core-version }}
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
@@ -47,7 +46,6 @@ jobs:
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
       cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
-      core-image: ghcr.io/calyptia/core:${{ needs.ci-get-metadata.outputs.core-version }}
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
@@ -94,7 +92,6 @@ jobs:
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
       cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
-      core-image: ghcr.io/calyptia/core:${{ needs.ci-get-metadata.outputs.core-version }}
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}

--- a/.github/workflows/create-self-hosted-stack.yaml
+++ b/.github/workflows/create-self-hosted-stack.yaml
@@ -58,10 +58,10 @@ jobs:
                 helm repo add calyptia https://helm.calyptia.com --force-update
                 helm repo update
                 helm upgrade --install core-instance calyptia/core-instance \
-                --set cloudToken="${CALYPTIA_CLOUD_TOKEN}" \
-                --set cloudUrl="${CALYPTIA_CLOUD_URL}" \
-                --set coreInstance=test \
-                --debug --wait
+                    --set cloudToken="${CALYPTIA_CLOUD_TOKEN}" \
+                    --set cloudUrl="${CALYPTIA_CLOUD_URL}" \
+                    --set coreInstance=test \
+                    --debug --wait
               shell: bash
 
             - uses: ./.github/actions/debug-cluster/

--- a/.github/workflows/get-versions.yaml
+++ b/.github/workflows/get-versions.yaml
@@ -17,8 +17,6 @@ on:
                 value: ${{ jobs.get-version.outputs.cloud-e2e-version }}
             core-fluent-bit-version:
                 value: ${{ jobs.get-version.outputs.core-fluent-bit-version }}
-            core-version:
-                value: ${{ jobs.get-version.outputs.core-version }}
             core-operator-version:
                 value: ${{ jobs.get-version.outputs.core-operator-version }}
             configmap-reload-version:
@@ -45,7 +43,6 @@ jobs:
             cloud-version: ${{ steps.cloud-version.outputs.version }}
             cloud-e2e-version: ${{ steps.cloud-e2e-version.outputs.version }}
             core-fluent-bit-version: ${{ steps.core-fluent-bit-version.outputs.version }}
-            core-version: ${{ steps.core-version.outputs.version }}
             core-operator-version: ${{ steps.core-operator-version.outputs.version }}
             configmap-reload-version: ${{ steps.configmap-reload-version.outputs.version }}
             frontend-version: ${{ steps.frontend-version.outputs.version }}
@@ -93,14 +90,6 @@ jobs:
               continue-on-error: true
               run: |
                 VERSION=$(jq -cr .versions.core_fluent_bit component-config.json)
-                echo "$VERSION"
-                echo "version=$VERSION" >> $GITHUB_OUTPUT
-              shell: bash
-
-            - id: core-version
-              continue-on-error: true
-              run: |
-                VERSION=$(jq -cr .versions.core component-config.json)
                 echo "$VERSION"
                 echo "version=$VERSION" >> $GITHUB_OUTPUT
               shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,6 @@ jobs:
               Release of Calyptia Core ${{ github.ref_name }}:
                 - CLI: ${{ needs.ci-get-metadata.outputs.cli-version }}
                 - Cloud: ${{ needs.ci-get-metadata.outputs.cloud-version }}
-                - Core: ${{ needs.ci-get-metadata.outputs.core-version }}
                 - Core Fluent Bit: ${{ needs.ci-get-metadata.outputs.core-fluent-bit-version }}
                 - Core Operator: ${{ needs.ci-get-metadata.outputs.core-operator-version }}
                 - Frontend: ${{ needs.ci-get-metadata.outputs.frontend-version }}

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -17,11 +17,6 @@ on:
               required: false
               default: ghcr.io/calyptia/cloud:latest
               description: docker image of calyptia/cloud
-            core-image:
-              type: string
-              required: false
-              default: ghcr.io/calyptia/core:main
-              description: docker image of calyptia-core
             core-operator-image:
               type: string
               required: false
@@ -45,7 +40,7 @@ on:
               description: The runner to use for tests.
               type: string
               required: false
-              default: actuated-4cpu-16gb
+              default: ubuntu-latest-m
             k8s-distribution:
               description: The K8S distribution to use for tests.
               type: choice
@@ -61,7 +56,6 @@ jobs:
           cli-version: ${{ inputs.cli-version }}
           cli-image: ${{ inputs.cli-image }}
           cloud-image: ${{ inputs.cloud-image }}
-          core-image: ${{ inputs.core-image }}
           core-operator-image: ${{ inputs.core-operator-image }}
           core-operator-from-cloud-image: ${{ inputs.core-operator-from-cloud-image }}
           core-operator-to-cloud-image: ${{ inputs.core-operator-to-cloud-image }}

--- a/component-config.json
+++ b/component-config.json
@@ -4,7 +4,6 @@
     "cloud": "1.7.1",
     "cloud_e2e": "1.6.5",
     "core_fluent_bit": "24.2.1",
-    "core": "1.4.0",
     "core_operator": "2.6.0",
     "configmap_reload": "0.11.1",
     "core_sidecar_ingest_check": "0.0.7",

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -216,9 +216,6 @@ EOF
         docker pull "$CALYPTIA_CLOUD_IMAGE"
         kind load docker-image "$CALYPTIA_CLOUD_IMAGE"
 
-        docker pull "$CALYPTIA_CORE_IMAGE"
-        kind load docker-image "$CALYPTIA_CORE_IMAGE"
-
         docker pull "$CALYPTIA_CORE_OPERATOR_IMAGE"
         kind load docker-image "$CALYPTIA_CORE_OPERATOR_IMAGE"
 


### PR DESCRIPTION
Remove usage of Actuated by default and switch to medium Github hosted runner for e2e tests.
Also tidy up usage of core-image which is no longer required: https://github.com/chronosphereio/calyptia-cloud-e2e/pull/165