### PR TITLE
Update all repo names after migration complete

### DIFF
--- a/.github/workflows/call-create-self-hosted-stack.yaml
+++ b/.github/workflows/call-create-self-hosted-stack.yaml
@@ -70,7 +70,7 @@ jobs:
             - name: Checkout self-hosted chart repo
               uses: actions/checkout@v4
               with:
-                repository: calyptia/core-product-release
+                repository: chronosphereio/calyptia-core-product-release
                 ref: ${{ inputs.ref }}
                 token: ${{ secrets.token }}
 

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -16,8 +16,8 @@
         cloud-image:
           type: string
           required: false
-          default: ghcr.io/calyptia/cloud:latest
-          description: docker image of calyptia/cloud
+          default: ghcr.io/chronosphereio/calyptia-cloud:latest
+          description: docker image of chronosphereio/calyptia-cloud
         core-operator-image:
           type: string
           required: false
@@ -40,8 +40,8 @@
         frontend-image:
           type: string
           required: false
-          default: ghcr.io/calyptia/frontend:main
-          description: docker image of calyptia/frontend
+          default: ghcr.io/chronosphereio/calyptia-frontend:latest
+          description: docker image of chronosphereio/calyptia-frontend
         lua-sandbox-image:
           type: string
           required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'disable-e2e-tests') }}
     needs:
       - ci-get-metadata
-    # We cannot run this from a public repo as the cloud-e2e repo is private so even though it shares workflows with the Calyptia org,
-    # they can only be run from a private calling repo.
-    # uses: calyptia/cloud-e2e/.github/workflows/call-integration-tests.yaml@main
-    # Instead we have to replicate the same workflow locally
     uses: ./.github/workflows/call-integration-tests.yaml
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
@@ -38,10 +34,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'openshift-build')
     needs:
       - ci-get-metadata
-    # We cannot run this from a public repo as the cloud-e2e repo is private so even though it shares workflows with the Calyptia org,
-    # they can only be run from a private calling repo.
-    # uses: calyptia/cloud-e2e/.github/workflows/call-integration-tests.yaml@main
-    # Instead we have to replicate the same workflow locally
     uses: ./.github/workflows/call-integration-tests.yaml
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
@@ -84,10 +76,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'enable-vcluster-tests')
     needs:
       - ci-get-metadata
-    # We cannot run this from a public repo as the cloud-e2e repo is private so even though it shares workflows with the Calyptia org,
-    # they can only be run from a private calling repo.
-    # uses: calyptia/cloud-e2e/.github/workflows/call-integration-tests.yaml@main
-    # Instead we have to replicate the same workflow locally
     uses: ./.github/workflows/call-integration-tests.yaml
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/call-integration-tests.yaml
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
-      cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
+      cloud-image: ghcr.io/chronosphereio/calyptia-cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/call-integration-tests.yaml
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
-      cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
+      cloud-image: ghcr.io/chronosphereio/calyptia-cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/call-integration-tests.yaml
     with:
       cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
-      cloud-image: ghcr.io/calyptia/cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
+      cloud-image: ghcr.io/chronosphereio/calyptia-cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}

--- a/.github/workflows/create-self-hosted-stack.yaml
+++ b/.github/workflows/create-self-hosted-stack.yaml
@@ -19,7 +19,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                repository: calyptia/api
+                repository: chronosphereio/calyptia-api
 
             - name: API schema tests
               run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
         contents: read
       strategy:
         matrix:
-          repo: ['calyptia/infra-gitops-configuration', 'calyptia/chart-cloud-standalone', 'chronosphereio/calyptia-core-docs']
+          repo: ['chronosphereio/calyptia-infra-gitops-configuration', 'chronosphereio/calyptia-chart-cloud-standalone', 'chronosphereio/calyptia-core-docs']
       steps:
         - uses: actions/checkout@v4
 

--- a/.github/workflows/run-integration-tests.yaml
+++ b/.github/workflows/run-integration-tests.yaml
@@ -15,8 +15,8 @@ on:
             cloud-image:
               type: string
               required: false
-              default: ghcr.io/calyptia/cloud:latest
-              description: docker image of calyptia/cloud
+              default: ghcr.io/chronosphereio/calyptia-cloud:latest
+              description: docker image of chronosphereio/calyptia-cloud
             core-operator-image:
               type: string
               required: false

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -21,6 +21,7 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
+CLOUD_VERSION=${CLOUD_VERSION:-$(jq -r .versions.cloud "$SCRIPT_DIR/../component-config.json")}
 CORE_FB_VERSION=${CORE_FB_VERSION:-$(jq -r .versions.core_fluent_bit "$SCRIPT_DIR/../component-config.json")}
 FRONTEND_VERSION=${FRONTEND_VERSION:-$(jq -r .versions.frontend "$SCRIPT_DIR/../component-config.json")}
 LUASANDBOX_VERSION=${LUASANDBOX_VERSION:-$(jq -r .versions.lua_sandbox "$SCRIPT_DIR/../component-config.json")}
@@ -34,7 +35,8 @@ declare -a images=("ghcr.io/calyptia/configmap-reload:$HOT_RELOAD_VERSION"
 "ghcr.io/calyptia/core-operator:$CORE_OPERATOR_VERSION"
 "ghcr.io/calyptia/core-operator/sync-to-cloud:$CORE_OPERATOR_VERSION"
 "ghcr.io/calyptia/core-operator/sync-from-cloud:$CORE_OPERATOR_VERSION"
-"ghcr.io/calyptia/frontend:$FRONTEND_VERSION"
+"ghcr.io/chronosphereio/calyptia-cloud:$CLOUD_VERSION"
+"ghcr.io/chronosphereio/calyptia-frontend:$FRONTEND_VERSION"
 "ghcr.io/calyptia/cloud-lua-sandbox:$LUASANDBOX_VERSION"
 )
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -284,7 +284,7 @@ function calyptiaCliInstall() {
             CALYPTIA_CLI_VERSION="${CALYPTIA_CLI_VERSION:-latest}"
             echo "Installing Calyptia CLI version: $CALYPTIA_CLI_VERSION"
             export cli_VERSION="$CALYPTIA_CLI_VERSION"
-            curl -sSfL https://raw.githubusercontent.com/calyptia/cli/main/install.sh | bash
+            curl -sSfL https://raw.githubusercontent.com/chronosphereio/calyptia-cli/main/install.sh | bash
         fi
     fi
     calyptia version


### PR DESCRIPTION
Final name updates for repos to remove redirects.
Fixes registry names now since we migrated private container images for cloud and frontend.