### PR TITLE
workflows: remove skipping of required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,7 @@ jobs:
   ci-get-metadata:
     uses: ./.github/workflows/get-versions.yaml
 
-  # Empty required check
-  ci-skip-e2e-tests:
-    name: Linux e2e tests complete
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'disable-e2e-tests') }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - run: echo Complete
-        shell: bash
-
   ci-e2e-tests:
-    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'disable-e2e-tests') }}
     needs:
       - ci-get-metadata
     uses: ./.github/workflows/call-integration-tests.yaml
@@ -72,10 +61,8 @@ jobs:
           - windows-latest
     with:
       calyptia-tests: "${{ matrix.testset }}/"
-      calyptia-lts-version: 23.10.2
+      calyptia-lts-version: 24.4.1
       runner: "${{ matrix.runner }}"
-      # TODO: update to main when changes have been merged
-      ref: pwhelan-fleet-e2e
       calyptia-cloud-url: "https://cloud-api-dev.calyptia.com"
     secrets:
       github-token: ${{ secrets.CI_PAT }}


### PR DESCRIPTION
https://github.com/chronosphereio/calyptia-core-product-release/pull/223 was incorrectly considered to have passed its required checks so simplified and removed the option to support skipping of them.