### PR TITLE
[sc-95865]: notify Slack on CVE detection

### DIFF
--- a/.github/workflows/call-generate-reports.yaml
+++ b/.github/workflows/call-generate-reports.yaml
@@ -55,7 +55,7 @@
                     OUTPUT_DIR: reports
 
                 - uses: actions/upload-artifact@v4
-                  if: always()
+                  if: github.ref_type == 'tag'
                   with:
                     name: reports
                     path: |

--- a/.github/workflows/call-generate-reports.yaml
+++ b/.github/workflows/call-generate-reports.yaml
@@ -55,6 +55,7 @@
                     OUTPUT_DIR: reports
 
                 - uses: actions/upload-artifact@v4
+                  if: always()
                   with:
                     name: reports
                     path: |

--- a/.github/workflows/cron-vuln-scan.yaml
+++ b/.github/workflows/cron-vuln-scan.yaml
@@ -1,0 +1,93 @@
+name: Regular CVE scan of components to trigger alerting
+on:
+    workflow_dispatch:
+    schedule:
+        # Every day at 0430 UTC
+        - cron: '30 4 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+    ci-get-metadata:
+        uses: ./.github/workflows/get-versions.yaml
+
+    ci-generate-alerts:
+        name: Trigger alerts for failing CVEs
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        needs:
+            - ci-get-metadata
+        strategy:
+            matrix:
+                container:
+                    - '${{ needs.ci-get-metadata.outputs.configmap-reload-image }}:${{ needs.ci-get-metadata.outputs.configmap-reload-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.core-fluent-bit-image }}:${{ needs.ci-get-metadata.outputs.core-fluent-bit-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.ingest-checks-image }}:${{ needs.ci-get-metadata.outputs.ingest-checks-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.core-operator-image }}:${{ needs.ci-get-metadata.outputs.core-operator-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.core-operator-sync-to-image }}:${{ needs.ci-get-metadata.outputs.core-operator-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.core-operator-sync-from-image }}:${{ needs.ci-get-metadata.outputs.core-operator-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.cloud-image }}:${{ needs.ci-get-metadata.outputs.cloud-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.frontend-image }}:${{ needs.ci-get-metadata.outputs.frontend-version }}'
+                    - '${{ needs.ci-get-metadata.outputs.lua-sandbox-image }}:${{ needs.ci-get-metadata.outputs.lua-sandbox-version }}'
+            fail-fast: false
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                registry: ghcr.io
+                username: ${{ github.actor }}
+                password: ${{ secrets.CI_PAT }}
+
+            - name: Scan image, table output for debug
+              uses: anchore/scan-action@v3
+              with:
+                image: ${{ matrix.container }}
+                by-cve: true
+                output-format: table
+
+            - name: Scan image
+              id: scan
+              uses: anchore/scan-action@v3
+              with:
+                image: ${{ matrix.container }}
+                fail-build: true
+                severity-cutoff: high
+                only-fixed: true
+                by-cve: true
+                output-format: json
+
+            - name: Upload output (if any)
+              id: upload
+              uses: actions/upload-artifact@v4
+              with:
+                name: cve-${{ matrix.container }}
+                path: ${{ steps.scan.outputs.json }}
+                retention-days: 90
+                if-no-files-found: ignore
+
+            - name: Send to Slack
+              if: failure()
+              uses: slackapi/slack-github-action@v1.26.0
+              with:
+                # pipeline-eng-notifications
+                channel-id: 'C06DW9RAT1B'
+                payload: |
+                    {
+                        "text": "CVE detected in ${{ matrix.container }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                        "blocks": [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": "Report: ${{ steps.upload.outputs.artifact-url }}"
+                                }
+                            }
+                        ]
+                    }
+              env:
+                SLACK_BOT_TOKEN: ${{ secrets.CVE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/cron-vuln-scan.yaml
+++ b/.github/workflows/cron-vuln-scan.yaml
@@ -61,14 +61,12 @@ jobs:
                 by-cve: true
                 output-format: json
 
-            - name: Upload output (if any)
-              id: upload
-              uses: actions/upload-artifact@v4
-              with:
-                name: cve-${{ matrix.container }}
-                path: ${{ steps.scan.outputs.json }}
-                retention-days: 90
-                if-no-files-found: ignore
+            - name: Capture output to stdout for usage in notification
+              id: output
+              run: |
+                cat ${{ steps.scan.outputs.json }}
+                echo "json=$(cat ${{ steps.scan.outputs.json }})" >> $GITHUB_OUTPUT
+              shell: bash
 
             - name: Send to Slack
               if: failure()
@@ -78,13 +76,13 @@ jobs:
                 channel-id: 'C06DW9RAT1B'
                 payload: |
                     {
-                        "text": "CVE detected in ${{ matrix.container }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                        "text": "CVE detected in ${{ matrix.container }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                         "blocks": [
                             {
-                                "type": "section",
+                                "type": "rich_text_preformatted",
                                 "text": {
-                                    "type": "mrkdwn",
-                                    "text": "Report: ${{ steps.upload.outputs.artifact-url }}"
+                                    "type": "text",
+                                    "text": "${{ steps.output.outputs.json }}"
                                 }
                             }
                         ]

--- a/.github/workflows/cron-vuln-scan.yaml
+++ b/.github/workflows/cron-vuln-scan.yaml
@@ -73,7 +73,7 @@ jobs:
               uses: slackapi/slack-github-action@v1.26.0
               with:
                 # pipeline-eng-notifications
-                channel-id: 'C06DW9RAT1B'
+                channel-id: ${{ secrets.CVE_SLACK_CHANNEL_ID }}
                 payload: |
                     {
                         "text": "CVE detected in ${{ matrix.container }}: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/get-versions.yaml
+++ b/.github/workflows/get-versions.yaml
@@ -39,6 +39,10 @@ on:
                 value: ${{ jobs.get-image.outputs.core-fluent-bit-image }}
             core-operator-image:
                 value: ${{ jobs.get-image.outputs.core-operator-image }}
+            core-operator-sync-to-image:
+                value: ${{ jobs.get-image.outputs.core-operator-sync-to-image }}
+            core-operator-sync-from-image:
+                value: ${{ jobs.get-image.outputs.core-operator-sync-from-image }}
             configmap-reload-image:
                 value: ${{ jobs.get-image.outputs.configmap-reload-image }}
             frontend-image:

--- a/.github/workflows/get-versions.yaml
+++ b/.github/workflows/get-versions.yaml
@@ -31,6 +31,22 @@ on:
                 value: ${{ jobs.get-version.outputs.k3s-test-versions }}
             lua-modules-version:
               value: ${{ jobs.get-version.outputs.lua-modules-version }}
+            ingest-checks-version:
+              value: ${{ jobs.get-version.outputs.ingest-checks-version }}
+            cloud-image:
+                value: ${{ jobs.get-image.outputs.cloud-image }}
+            core-fluent-bit-image:
+                value: ${{ jobs.get-image.outputs.core-fluent-bit-image }}
+            core-operator-image:
+                value: ${{ jobs.get-image.outputs.core-operator-image }}
+            configmap-reload-image:
+                value: ${{ jobs.get-image.outputs.configmap-reload-image }}
+            frontend-image:
+                value: ${{ jobs.get-image.outputs.frontend-image }}
+            lua-sandbox-image:
+                value: ${{ jobs.get-image.outputs.lua-sandbox-image }}
+            ingest-checks-image:
+              value: ${{ jobs.get-image.outputs.ingest-checks-image }}
 jobs:
     get-version:
         name: Get the core-product-release versions
@@ -50,6 +66,7 @@ jobs:
             lua-modules-version: ${{ steps.lua-modules-version.outputs.version }}
             k8s-test-versions: ${{ steps.k8s-test-versions.outputs.version }}
             k3s-test-versions: ${{ steps.k3s-test-versions.outputs.version }}
+            ingest-checks-version: ${{ steps.ingest-checks-version.outputs.version }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -144,6 +161,112 @@ jobs:
             - id: k3s-test-versions
               run: |
                 VERSION=$(jq -cr .k8s_k3s_versions component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: ingest-checks-version
+              run: |
+                VERSION=$(jq -cr .versions.core_sidecar_ingest_check component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+    get-image:
+        name: Get the core-product-release images
+        runs-on: ubuntu-latest
+        permissions:
+            # Public repo so no token required
+            contents: none
+        outputs:
+            cloud-image: ${{ steps.cloud-image.outputs.image }}
+            core-fluent-bit-image: ${{ steps.core-fluent-bit-image.outputs.image }}
+            core-operator-image: ${{ steps.core-operator-image.outputs.image }}
+            core-operator-sync-to-image: ${{ steps.core-operator-sync-to-image.outputs.image }}
+            core-operator-sync-from-image: ${{ steps.core-operator-sync-from-image.outputs.image }}
+            configmap-reload-image: ${{ steps.configmap-reload-image.outputs.image }}
+            frontend-image: ${{ steps.frontend-image.outputs.image }}
+            lua-sandbox-image: ${{ steps.lua-sandbox-image.outputs.image }}
+            ingest-checks-image: ${{ steps.ingest-checks-image.outputs.image }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                repository: chronosphereio/calyptia-core-product-release
+                ref: ${{ inputs.ref }}
+
+            - name: Install dependencies
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y jq
+              shell: bash
+
+            - id: cloud-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.cloud component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: core-fluent-bit-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.core_fluent_bit component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: core-operator-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.core_operator component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: core-operator-sync-to-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.core_operator_sync_to component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: core-operator-sync-from-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.core_operator_sync_from component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: configmap-reload-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.configmap_reload component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: frontend-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.frontend component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: lua-sandbox-image
+              continue-on-error: true
+              run: |
+                VERSION=$(jq -cr .containers.lua_sandbox component-config.json)
+                echo "$VERSION"
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              shell: bash
+
+            - id: ingest-checks-image
+              run: |
+                VERSION=$(jq -cr .containers.core_sidecar_ingest_check component-config.json)
                 echo "$VERSION"
                 echo "version=$VERSION" >> $GITHUB_OUTPUT
               shell: bash

--- a/component-config.json
+++ b/component-config.json
@@ -11,6 +11,17 @@
     "lua_sandbox": "4.2.0",
     "lua_modules": "6.1.1"
   },
+  "containers": {
+    "cloud": "ghcr.io/chronosphereio/calyptia-cloud",
+    "frontend": "ghcr.io/chronosphereio/calyptia-frontend",
+    "core_fluent_bit": "ghcr.io/calyptia/core/calyptia-fluent-bit",
+    "core_operator": "ghcr.io/calyptia/core-operator",
+    "core_operator_sync_to": "ghcr.io/calyptia/core-operator/sync-to-cloud",
+    "core_operator_sync_from": "ghcr.io/calyptia/core-operator/sync-from-cloud",
+    "configmap_reload": "ghcr.io/calyptia/configmap-reload",
+    "core_sidecar_ingest_check": "ghcr.io/calyptia/core/ingest-check",
+    "lua_sandbox": "ghcr.io/calyptia/cloud-lua-sandbox"
+  },
   "k8s_kind_versions": [
     "v1.27.3",
     "v1.25.11",

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -29,15 +29,25 @@ CORE_OPERATOR_VERSION=${CORE_OPERATOR_VERSION:-$(jq -r .versions.core_operator "
 HOT_RELOAD_VERSION=${HOT_RELOAD_VERSION:-$(jq -r .versions.configmap_reload "$SCRIPT_DIR/../component-config.json")}
 INGEST_CHECKS_VERSION=${INGEST_CHECKS_VERSION:-$(jq -r .versions.core_sidecar_ingest_check "$SCRIPT_DIR/../component-config.json")}
 
-declare -a images=("ghcr.io/calyptia/configmap-reload:$HOT_RELOAD_VERSION"
-"ghcr.io/calyptia/core/calyptia-fluent-bit:$CORE_FB_VERSION"
-"ghcr.io/calyptia/core/ingest-check:$INGEST_CHECKS_VERSION"
-"ghcr.io/calyptia/core-operator:$CORE_OPERATOR_VERSION"
-"ghcr.io/calyptia/core-operator/sync-to-cloud:$CORE_OPERATOR_VERSION"
-"ghcr.io/calyptia/core-operator/sync-from-cloud:$CORE_OPERATOR_VERSION"
-"ghcr.io/chronosphereio/calyptia-cloud:$CLOUD_VERSION"
-"ghcr.io/chronosphereio/calyptia-frontend:$FRONTEND_VERSION"
-"ghcr.io/calyptia/cloud-lua-sandbox:$LUASANDBOX_VERSION"
+CLOUD_IMAGE=${CLOUD_IMAGE:-$(jq -r .containers.cloud "$SCRIPT_DIR/../component-config.json")}
+CORE_FB_IMAGE=${CORE_FB_IMAGE:-$(jq -r .containers.core_fluent_bit "$SCRIPT_DIR/../component-config.json")}
+FRONTEND_IMAGE=${FRONTEND_IMAGE:-$(jq -r .containers.frontend "$SCRIPT_DIR/../component-config.json")}
+LUASANDBOX_IMAGE=${LUASANDBOX_IMAGE:-$(jq -r .containers.lua_sandbox "$SCRIPT_DIR/../component-config.json")}
+CORE_OPERATOR_IMAGE=${CORE_OPERATOR_IMAGE:-$(jq -r .containers.core_operator "$SCRIPT_DIR/../component-config.json")}
+CORE_OPERATOR_SYNC_TO_IMAGE=${CORE_OPERATOR_SYNC_TO_IMAGE:-$(jq -r .containers.core_operator_sync_to "$SCRIPT_DIR/../component-config.json")}
+CORE_OPERATOR_SYNC_FROM_IMAGE=${CORE_OPERATOR_SYNC_FROM_IMAGE:-$(jq -r .containers.core_operator_sync_from "$SCRIPT_DIR/../component-config.json")}
+HOT_RELOAD_IMAGE=${HOT_RELOAD_IMAGE:-$(jq -r .containers.configmap_reload "$SCRIPT_DIR/../component-config.json")}
+INGEST_CHECKS_IMAGE=${INGEST_CHECKS_IMAGE:-$(jq -r .containers.core_sidecar_ingest_check "$SCRIPT_DIR/../component-config.json")}
+
+declare -a images=("$HOT_RELOAD_IMAGE:$HOT_RELOAD_VERSION"
+"$CORE_FB_IMAGE:$CORE_FB_VERSION"
+"$INGEST_CHECKS_IMAGE:$INGEST_CHECKS_VERSION"
+"$CORE_OPERATOR_IMAGE:$CORE_OPERATOR_VERSION"
+"$CORE_OPERATOR_SYNC_TO_IMAGE:$CORE_OPERATOR_VERSION"
+"$CORE_OPERATOR_SYNC_FROM_IMAGE:$CORE_OPERATOR_VERSION"
+"$CLOUD_IMAGE:$CLOUD_VERSION"
+"$FRONTEND_IMAGE:$FRONTEND_VERSION"
+"$LUASANDBOX_IMAGE:$LUASANDBOX_VERSION"
 )
 
 rm -rf "${OUTPUT_DIR:?}/*"


### PR DESCRIPTION
Part of work for [sc-95865], this adds a new workflow that regularly scans our production images for CVEs and notifies Slack if so.

It is awaiting Slack configuration secrets plus new workflows have to merge to `main` to be tested. We are using this approach: https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-app

The `component-config.json` file now includes container images too.

The intent is to build on this once we are happy the Slack notification is working to provide further integration with PD, etc. as required.