### PR TITLE
[sc-96951}: ensure we use current git ref for checkout

### DIFF
--- a/.github/workflows/call-fleet-integration-tests.yaml
+++ b/.github/workflows/call-fleet-integration-tests.yaml
@@ -14,6 +14,11 @@ on:
         description: package artefact for calyptia fluent-bit
         default: ""
       ref:
+        description: The commit, tag or branch of the cloud-e2e repository to checkout
+        type: string
+        required: false
+        default: refs/heads/main
+      cpr-ref:
         description: The commit, tag or branch of this repository to checkout
         type: string
         required: false

--- a/.github/workflows/call-integration-tests.yaml
+++ b/.github/workflows/call-integration-tests.yaml
@@ -52,6 +52,11 @@
           type: string
           required: false
           default: refs/heads/main
+        cpr-ref:
+          description: The commit, tag or branch of this repository to checkout
+          type: string
+          required: false
+          default: refs/heads/main
         calyptia-tests:
           description: Path to tests to be executed
           type: string
@@ -119,10 +124,11 @@
       # permissions:
       #   contents: read
       uses: ./.github/workflows/get-versions.yaml
+      with:
+        ref: ${{ inputs.cpr-ref }}
 
     run-integration-tests-linux:
       name: Linux e2e tests
-      if: (inputs.k8s-distribution == 'kind' || inputs.k8s-distribution == 'vcluster') && !(contains(inputs.runner, 'mac') || contains(inputs.runner, 'windows'))
       needs:
         - get-versions
       # permissions:
@@ -136,7 +142,7 @@
         matrix:
           # Be aware the KIND and K8S image versions may need to be compatible
           # https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
-          k8s-release: ${{ (inputs.k8s-distribution == 'vcluster' && fromJSON(needs.get-versions.outputs.k3s-test-versions)) || fromJSON(needs.get-versions.outputs.k8s-test-versions) }}
+          k8s-release: ${{ fromJSON(needs.get-versions.outputs.k8s-test-versions) }}
       runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
       steps:
         - name: Set up Actuated mirror
@@ -147,6 +153,7 @@
           with:
             repository: chronosphereio/calyptia-core-product-release
             path: core-product-release
+            ref: ${{ inputs.cpr-ref }}
 
         - name: Checkout the e2e test code
           uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   ci-get-metadata:
     uses: ./.github/workflows/get-versions.yaml
+    with:
+      ref: ${{ github.ref }}
 
   ci-e2e-tests:
     needs:
@@ -22,29 +24,10 @@ jobs:
       core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
       core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
+      cpr-ref: ${{ github.ref }}
     secrets:
       registry-username: ${{ secrets.CI_USERNAME }}
       registry-password: ${{ secrets.CI_PAT }}
-      # Replace with playground key after: https://app.asana.com/0/1205042382663691/1205231066738712/f
-      google-access-key: ${{ secrets.GCP_SA_KEY }}
-      github-token: ${{ secrets.CI_PAT }}
-
-  ci-e2e-tests-openshift:
-    if: contains(github.event.pull_request.labels.*.name, 'openshift-build')
-    needs:
-      - ci-get-metadata
-    uses: ./.github/workflows/call-integration-tests.yaml
-    with:
-      cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
-      cloud-image: ghcr.io/chronosphereio/calyptia-cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
-      core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
-      core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
-      core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
-      k8s-distribution: openshift
-    secrets:
-      registry-username: ${{ secrets.CI_USERNAME }}
-      registry-password: ${{ secrets.CI_PAT }}
-      # Replace with playground key after: https://app.asana.com/0/1205042382663691/1205231066738712/f
       google-access-key: ${{ secrets.GCP_SA_KEY }}
       github-token: ${{ secrets.CI_PAT }}
 
@@ -67,27 +50,6 @@ jobs:
     secrets:
       github-token: ${{ secrets.CI_PAT }}
       calyptia-cloud-token: ${{ secrets.CALYPTIA_CLOUD_TOKEN }}
-
-  ci-e2e-tests-vcluster:
-    # remove if decide to replace kind tests
-    if: contains(github.event.pull_request.labels.*.name, 'enable-vcluster-tests')
-    needs:
-      - ci-get-metadata
-    uses: ./.github/workflows/call-integration-tests.yaml
-    with:
-      cli-version: v${{ needs.ci-get-metadata.outputs.cli-version }}
-      cloud-image: ghcr.io/chronosphereio/calyptia-cloud:${{ needs.ci-get-metadata.outputs.cloud-version }}
-      core-operator-image: ghcr.io/calyptia/core-operator:${{ needs.ci-get-metadata.outputs.core-operator-version }}
-      core-operator-from-cloud-image: ghcr.io/calyptia/core-operator/sync-from-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
-      core-operator-to-cloud-image: ghcr.io/calyptia/core-operator/sync-to-cloud:${{ needs.ci-get-metadata.outputs.core-operator-version }}
-      k8s-distribution: "vcluster"
-      runner: "ubuntu-latest"
-    secrets:
-      registry-username: ${{ secrets.CI_USERNAME }}
-      registry-password: ${{ secrets.CI_PAT }}
-      # Replace with playground key after: https://app.asana.com/0/1205042382663691/1205231066738712/f
-      google-access-key: ${{ secrets.GCP_SA_KEY }}
-      github-token: ${{ secrets.CI_PAT }}
 
   ci-generate-reports:
     name: Generate SBOM and CVE reports for release

--- a/.github/workflows/get-versions.yaml
+++ b/.github/workflows/get-versions.yaml
@@ -30,9 +30,9 @@ on:
             k3s-test-versions:
                 value: ${{ jobs.get-version.outputs.k3s-test-versions }}
             lua-modules-version:
-              value: ${{ jobs.get-version.outputs.lua-modules-version }}
+                value: ${{ jobs.get-version.outputs.lua-modules-version }}
             ingest-checks-version:
-              value: ${{ jobs.get-version.outputs.ingest-checks-version }}
+                value: ${{ jobs.get-version.outputs.ingest-checks-version }}
             cloud-image:
                 value: ${{ jobs.get-image.outputs.cloud-image }}
             core-fluent-bit-image:
@@ -50,7 +50,7 @@ on:
             lua-sandbox-image:
                 value: ${{ jobs.get-image.outputs.lua-sandbox-image }}
             ingest-checks-image:
-              value: ${{ jobs.get-image.outputs.ingest-checks-image }}
+                value: ${{ jobs.get-image.outputs.ingest-checks-image }}
 jobs:
     get-version:
         name: Get the core-product-release versions


### PR DESCRIPTION
Resolves issues seen during tests where it checks out `main` and uses versions from that.
Also tidies up Openshift/vCluster tests which are no longer present.

You can see now it takes the PR branch: https://github.com/chronosphereio/calyptia-core-product-release/actions/runs/9483906392/job/26132144358?pr=301
```
Run actions/checkout@v4
  with:
    repository: chronosphereio/calyptia-core-product-release
    ref: refs/pull/301/merge
```
Unlike a previous PR: https://github.com/chronosphereio/calyptia-core-product-release/actions/runs/9482631201/job/26127922234
```
Run actions/checkout@v4
  with:
    repository: chronosphereio/calyptia-core-product-release
    ref: main
```