### PR TITLE
workflows: ensure we checkout the PR branch for cve scans

### DIFF
--- a/.github/workflows/cron-vuln-scan.yaml
+++ b/.github/workflows/cron-vuln-scan.yaml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
     ci-get-metadata:
         uses: ./.github/workflows/get-versions.yaml
+        with:
+          ref: ${{ github.ref }}
 
     ci-generate-alerts:
         name: Trigger alerts for failing CVEs


### PR DESCRIPTION
Resolves issues with scanning from `main` instead of the `pr`.